### PR TITLE
Add food & drink properties to vegetables

### DIFF
--- a/assets/prefabs/Cucumber/Cucumber.prefab
+++ b/assets/prefabs/Cucumber/Cucumber.prefab
@@ -14,5 +14,11 @@
     "bud": "AdditionalVegetables:CucumberBud",
     "minGrowTime": 4000,
     "maxGrowTime": 7000
+  },
+  "Food": {
+    "filling": 0.6
+  },
+  "Drink": {
+    "filling": 0.5
   }
 }

--- a/assets/prefabs/Potato/Potato.prefab
+++ b/assets/prefabs/Potato/Potato.prefab
@@ -12,7 +12,7 @@
     "type": "Potato"
   },
   "Food": {
-    "filling": 0.6
+    "filling": 2
   },
   "ItemHelp": {
     "category": "Edible Flora",

--- a/assets/prefabs/Squash/Squash.prefab
+++ b/assets/prefabs/Squash/Squash.prefab
@@ -8,6 +8,12 @@
   "DisplayName": {
     "name": "Squash"
   },
+  "Food": {
+    "filling": 1
+  },
+  "Drink": {
+    "filling": 0.5
+  },
   "SeedDefinition": {},
   "VineDefinition": {
     "stem": "AdditionalVegetables:SquashVineStem",


### PR DESCRIPTION
Some vegetables that should be consumable weren't consumable at all by the player. This PR adds consumable food & drink properties to all vegetables, except for the pumpkin. Slight variations exist between all vegetables based on water content and size.